### PR TITLE
Add short string to array

### DIFF
--- a/byteutils.nim
+++ b/byteutils.nim
@@ -37,10 +37,8 @@ proc readHexChar*(c: char): byte {.noSideEffect, inline.}=
 template skip0xPrefix(hexStr: string): int =
   ## Returns the index of the first meaningful char in `hexStr` by skipping
   ## "0x" prefix
-  if hexStr[0] == '0' and hexStr[1] in {'x', 'X'}:
-    2
-  else:
-    0
+  if hexStr[0] == '0' and hexStr[1] in {'x', 'X'}: 2
+  else: 0
 
 func hexToByteArray*(hexStr: string, output: var openArray[byte], fromIdx, toIdx: int) =
   ## Read a hex string and store it in a byte array `output`. No "endianness" reordering is done.

--- a/byteutils.nim
+++ b/byteutils.nim
@@ -65,6 +65,30 @@ func hexToByteArray*[N: static[int]](hexStr: string): array[N, byte] {.noInit, i
   ## Read an hex string and store it in a byte array. No "endianness" reordering is done.
   hexToByteArray(hexStr, result)
 
+func hexToPaddedByteArray*[N: static[int]](hexStr: string): array[N, byte] {.inline.}=
+  ## Read a hex string and store it in a byte array `output`.
+  ## The string may be shorter than the byte array.
+  ## No "endianness" reordering is done.
+  let
+    p = skip0xPrefix(hexStr)
+    sz = hexStr.len - p
+    maxStrSize = result.len * 2
+  var bIdx, shift: int
+
+  doAssert hexStr.len - p <= maxStrSize
+  
+  if hexStr.len < maxStrSize:
+    # include extra byte if odd length
+    bIdx = result.len - (sz + 1) div 2   
+    # start with shl of 4 if length is even
+    shift = 4 - sz mod 2 * 4
+
+  for sIdx in p ..< hexStr.len:
+    let nibble = hexStr[sIdx].readHexChar shl shift
+    result[bIdx] = result[bIdx] or nibble
+    shift = shift + 4 and 4
+    bIdx += shift shr 2
+
 func hexToSeqByte*(hexStr: string): seq[byte] =
   ## Read an hex string and store it in a sequence of bytes. No "endianness" reordering is done.
   var i = skip0xPrefix(hexStr)

--- a/byteutils.nim
+++ b/byteutils.nim
@@ -63,7 +63,7 @@ func hexToByteArray*[N: static[int]](hexStr: string): array[N, byte] {.noInit, i
   ## Read an hex string and store it in a byte array. No "endianness" reordering is done.
   hexToByteArray(hexStr, result)
 
-func hexToPaddedByteArray*[N: static[int]](hexStr: string): array[N, byte] {.inline.}=
+func hexToPaddedByteArray*[N: static[int]](hexStr: string): array[N, byte] =
   ## Read a hex string and store it in a byte array `output`.
   ## The string may be shorter than the byte array.
   ## No "endianness" reordering is done.

--- a/byteutils.nim
+++ b/byteutils.nim
@@ -73,11 +73,13 @@ func hexToPaddedByteArray*[N: static[int]](hexStr: string): array[N, byte] {.inl
     p = skip0xPrefix(hexStr)
     sz = hexStr.len - p
     maxStrSize = result.len * 2
-  var bIdx, shift: int
+  var
+    bIdx: int
+    shift = 4
 
   doAssert hexStr.len - p <= maxStrSize
   
-  if hexStr.len < maxStrSize:
+  if sz < maxStrSize:
     # include extra byte if odd length
     bIdx = result.len - (sz + 1) div 2   
     # start with shl of 4 if length is even

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -52,3 +52,6 @@ suite "Byte utils":
     block:
       let a = hexToPaddedByteArray[32]("0x68656c6c6f20776f726c64")
       check a.toHex == "00000000000000000000000000000000000000000068656c6c6f20776f726c64"
+    block:
+      expect AssertionError:
+        let a = hexToPaddedByteArray[2]("0x12345")

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -36,3 +36,19 @@ suite "Byte utils":
     check simpleBArray & simpleBArray ==
       [0x12.byte, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78]
 
+  test "hexToPaddedByteArray":
+    block:
+      let a = hexToPaddedByteArray[4]("0x123")
+      check a.toHex == "00000123"
+    block:
+      let a = hexToPaddedByteArray[4]("0x1234")
+      check a.toHex == "00001234"
+    block:
+      let a = hexToPaddedByteArray[4]("0x1234567")
+      check a.toHex == "01234567"
+    block:
+      let a = hexToPaddedByteArray[4]("0x12345678")
+      check a.toHex == "12345678"
+    block:
+      let a = hexToPaddedByteArray[32]("0x68656c6c6f20776f726c64")
+      check a.toHex == "00000000000000000000000000000000000000000068656c6c6f20776f726c64"


### PR DESCRIPTION
Adds a helper function to allow converting compact strings like "0x1" into larger arrays, for example 32 bytes.